### PR TITLE
Support more than two macro arguments

### DIFF
--- a/picaxepreprocess.py
+++ b/picaxepreprocess.py
@@ -324,22 +324,13 @@ Called from line {} in '{}'""".format(curpath, curfilename, called_from_line, ca
                             # line=line+"      'DEFINE: "+value+" SUBSTITUTED FOR "+key+"\n"
                     for key, macrovars in macros.items():
                         if key in line:
-                            params={}
-                            argnum=0
                             macrocontents=line.split(key)[1]
                             macrocontents=macrocontents.strip().strip("(").strip(")")
-                            while(1):
-                                argnum+=1
-                            
-                                if "," in macrocontents:
-                                    params[argnum]=macrocontents.split(",")[0].rstrip()   #
-                                    
-                                    macrocontents=macrocontents.split(",")[1].strip() # Remove the first parameter nd try again 
-                                else:
-                                    preprocessor_info("finished parsing macro contents")
-                                    params[argnum]=macrocontents.split(",")[0].rstrip()
-                                    preprocessor_info(params)
-                                    break
+
+                            params = {i + 1: m.rstrip() for i, m in enumerate(macrocontents.split(','))}
+                            preprocessor_info("finished parsing macro params")
+                            preprocessor_info(params)
+
                             line = replace(key, macrovars[0], line)
 
                             # # Make sure each line is commented out in a multiline macro if the surrounding code should be commented out
@@ -383,7 +374,7 @@ Called from line {} in '{}'""".format(curpath, curfilename, called_from_line, ca
                             preprocessor_info("Old define found, leaving intact")
                             # Make it replace any call to itdelf with itself so that it is in the dictionary for ifdef
                             definitions[workingline.split()[0]] = workingline.split()[0]
-                        
+
                         with open (outputfilename, 'a') as output_file:
                             output_file.write("; " + line.rstrip()+"\n") # Comment out to make sure
                             # this script does all processing and there isn't the risk of the
@@ -406,25 +397,13 @@ Called from line {} in '{}'""".format(curpath, curfilename, called_from_line, ca
                         preprocessor_info(macroname)
                         with open (outputfilename, 'a') as output_file:
                             output_file.write("'PARSED MACRO "+macroname)
-                        macrocontents=workingline.split("(")[1].rstrip()
-                        macros[macroname]={}
-                        argnum=0
-                        while(1):
-                            argnum+=1
-                            if macrocontents.strip()==")":
-                                preprocessor_info("no parameters to macro")
-                                macros[macroname][0]="'Start of macro: "+macroname+"\n"
-                                preprocessor_info(macros)
-                                break
-                            else:
-                                macrocontents=macrocontents.rstrip(")").strip("(")
-                                macros[macroname][argnum]=macrocontents.split(",")[0].rstrip()   #create spot in dictionary for macro variables, but don't populate yet
-                                if "," in macrocontents:
-                                    macrocontents=macrocontents.split(",")[1].strip().rstrip()
-                                else:
-                                    preprocessor_info("finished parsing macro contents")
-                                    macros[macroname][0]="'--START OF MACRO: "+macroname+"\n"
-                                    break
+                        macrocontents=workingline.split("(", maxsplit=1)[1].split(")", maxsplit=1)[0].rstrip()
+
+                        macros[macroname] = {i + 1: m.rstrip() for i, m in enumerate(macrocontents.split(','))}
+                        macros[macroname][0]="'--START OF MACRO: "+macroname+"\n"
+                        preprocessor_info("finished parsing macro contents")
+                        preprocessor_info(macros[macroname])
+
                     elif savingmacro==True:
                         if workingline.lower().startswith("#endmacro"):
                             savingmacro=False

--- a/picaxepreprocess.py
+++ b/picaxepreprocess.py
@@ -398,8 +398,7 @@ Called from line {} in '{}'""".format(curpath, curfilename, called_from_line, ca
                         with open (outputfilename, 'a') as output_file:
                             output_file.write("'PARSED MACRO "+macroname)
                         macrocontents=workingline.split("(", maxsplit=1)[1].split(")", maxsplit=1)[0].rstrip()
-
-                        macros[macroname] = {i + 1: m.rstrip() for i, m in enumerate(macrocontents.split(','))}
+                        macros[macroname] = {i + 1: m.strip() for i, m in enumerate(macrocontents.split(','))}
                         macros[macroname][0]="'--START OF MACRO: "+macroname+"\n"
                         preprocessor_info("finished parsing macro contents")
                         preprocessor_info(macros[macroname])


### PR DESCRIPTION
Not including `maxsplit=1` meant that only two macro arguments were
ever processed. This new code is a lot simpler and uses a dictionary
comprehension to build the argument lists.

Note that this implementation still fails on some inputs - for example,
any string that contains a comma. However, that's an existing issue, not
affected by this patch. It can only be solved by proper lexing of the
source code, which could be a pretty big task. I'd recommend the use of
`shlex` if you don't want to require a third-party library.